### PR TITLE
cambio de clase para que la tabla se adapte a todas las pantallas

### DIFF
--- a/app/views/pedidos/index.html.erb
+++ b/app/views/pedidos/index.html.erb
@@ -4,7 +4,7 @@
 <div class="orders">
   <div class="row">
       <h3>Mis pedidos</h3>
-      <table class='table table-striped' data-search="true">
+	  <table class='table' data-search="true">
         <thead>
           <tr>
             <th>Número de pedido</th>


### PR DESCRIPTION
Hay un temita con la clase table-striped de bootstrap que oculta la tabla cuándo el ancho de la pantalla es menor de 320px. Sacando esa clase anda bien